### PR TITLE
Fix conversion of u32 to ULEB128

### DIFF
--- a/Sources/Serde/BcsSerializer.swift
+++ b/Sources/Serde/BcsSerializer.swift
@@ -13,7 +13,7 @@ public class BcsSerializer: BinarySerializer {
     private func serialize_u32_as_uleb128(value: UInt32) throws {
         var input = value
         while input >= 0x80 {
-            writeByte(UInt8((value & 0x7F) | 0x80))
+            writeByte(UInt8((input & 0x7F) | 0x80))
             input >>= 7
         }
         writeByte(UInt8(input))

--- a/Tests/SerdeTests/SerdeTests.swift
+++ b/Tests/SerdeTests/SerdeTests.swift
@@ -139,4 +139,13 @@ class SerdeTests: XCTestCase {
         s.sort_map_entries(offsets: offsets)
         XCTAssertEqual(s.get_bytes(), [255 /**/, 0 /**/, 0 /**/, 0, 0 /**/, 0, 1, 0 /**/, 1 /**/, 2, 0, 0, 0])
     }
+
+    func testBcsSerializerRoundTripsBytes() throws {
+        let bytes = [UInt8](repeating: 77, count: 20_000)
+        let serializer = BcsSerializer()
+        try serializer.serialize_bytes(value: bytes)
+        let deserializer = BcsDeserializer(input: serializer.get_bytes())
+        let result = try deserializer.deserialize_bytes()
+        XCTAssertEqual(result, bytes, "should match")
+    }
 }


### PR DESCRIPTION
Previously, long arrays had their lengths serialized incorrectly.